### PR TITLE
Removed SteamID-by-IP hack.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,17 @@ A SourceMod library allowing clients to pick and choose their downloads.
 
 Provides a bunch of methods to store and retrieve preferences for groups of files that are expected to be downloaded across maps.
 Combined with a PHP script to read preferences for clients by IP address and a rewrite rule in the HTTPD of choice, this allows a web server to prevent clients from downloading files that they do not want.
+
+How to Set Up
+-------------
+1.  Copy contents from `./www/` to your fast download server's `/tf/` directory.
+2.  [pending]
+
+Example Rewrite Rules
+---------------------
+
+In lighttpd:
+
+```
+	url.rewrite-once += ( "^/tf-dprefs/(\d+)/(.*)" => "/tf/downloadprefs_sqlite.php?steamid=$1&file=$2" )
+```

--- a/scripting/downloadprefs.sp
+++ b/scripting/downloadprefs.sp
@@ -2,25 +2,25 @@
  * Download Preferences
  * Author(s): nosoop
  * File:  downloadprefs.sp
- * Description:  Allows clients to select categories of files to download.
- * License:  MIT License
+ * Description:	 Allows clients to select categories of files to download.
+ * License:	 MIT License
  */
 
 #pragma semicolon 1
 
 #include <sourcemod>
 
-#define PLUGIN_VERSION          "0.3.1"
+#define PLUGIN_VERSION			"0.3.1"
 
 public Plugin:myinfo = {
-    name = "Download Preferences",
-    author = "nosoop",
-    description = "Client download preferences",
-    version = PLUGIN_VERSION,
-    url = "http://github.com/nosoop/SM-DownloadPrefs"
+	name = "Download Preferences",
+	author = "nosoop",
+	description = "Client download preferences",
+	version = PLUGIN_VERSION,
+	url = "http://github.com/nosoop/SM-DownloadPrefs"
 }
 
-#define DATABASE_NAME           "downloadprefs" // Database name in config
+#define DATABASE_NAME			"downloadprefs" // Database name in config
 
 new Handle:g_hDatabase = INVALID_HANDLE;
 
@@ -38,21 +38,21 @@ public OnPluginStart() {
 }
 
 public OnPluginEnd() {
-    CloseHandle(g_hDatabase);
+	CloseHandle(g_hDatabase);
 }
 
 public APLRes:AskPluginLoad2(Handle:hMySelf, bool:bLate, String:strError[], iMaxErrors) {
-    RegPluginLibrary("downloadprefs");
+	RegPluginLibrary("downloadprefs");
 
-    CreateNative("RegClientDownloadCategory", Native_RegClientDownloadCategory);
-    CreateNative("RegClientDownloadFile", Native_RegClientDownloadFile);
-    CreateNative("SetClientDownloadPreference", Native_SetClientDownloadPreference);
-    CreateNative("GetClientDownloadPreference", Native_GetClientDownloadPreference);
-    CreateNative("ClientHasDownloadPreference", Native_ClientHasDownloadPreference);
+	CreateNative("RegClientDownloadCategory", Native_RegClientDownloadCategory);
+	CreateNative("RegClientDownloadFile", Native_RegClientDownloadFile);
+	CreateNative("SetClientDownloadPreference", Native_SetClientDownloadPreference);
+	CreateNative("GetClientDownloadPreference", Native_GetClientDownloadPreference);
+	CreateNative("ClientHasDownloadPreference", Native_ClientHasDownloadPreference);
 
-    g_hDatabase = GetDatabase();
-    
-    return APLRes_Success;
+	g_hDatabase = GetDatabase();
+	
+	return APLRes_Success;
 }
 
 /**
@@ -60,9 +60,9 @@ public APLRes:AskPluginLoad2(Handle:hMySelf, bool:bLate, String:strError[], iMax
  * Also stores the current time in the event a database pruning is desirable.
  */
 public OnClientAuthorized(client, const String:auth[]) {
-    if (!IsFakeClient(client)) {
-        SendCustomDownloadDirectory(client);
-    }
+	if (!IsFakeClient(client)) {
+		SendCustomDownloadDirectory(client);
+	}
 }
 
 SendCustomDownloadDirectory(client) {
@@ -88,15 +88,15 @@ SendCustomDownloadDirectory(client) {
  * Store the category plus description into the database if nonexistent, 
  * returning an ID to the corresponding category.
  * 
- * @param category          The category name to register.
- * @param description       The description associated with the category.
- * @param enabled           The file group is downloaded by default; clients must choose to opt-out.
+ * @param category			The category name to register.
+ * @param description		The description associated with the category.
+ * @param enabled			The file group is downloaded by default; clients must choose to opt-out.
  * 
- * @return categoryid       The ID of the category.
+ * @return categoryid		The ID of the category.
  */
 _:RegClientDownloadCategory(const String:category[], const String:description[], bool:enabled = true) {
-    new Handle:hQuery = INVALID_HANDLE, iCategoryID;
-    decl String:sQuery[1024];
+	new Handle:hQuery = INVALID_HANDLE, iCategoryID;
+	decl String:sQuery[1024];
 	
 	Format(sQuery, sizeof(sQuery),
 			"SELECT categoryid FROM categories WHERE categoryname='%s'",
@@ -109,190 +109,190 @@ _:RegClientDownloadCategory(const String:category[], const String:description[],
 				category, description, enabled);
 		SQL_FastQuery(g_hDatabase, sQuery);
 	}
-    CloseHandle(hQuery);
+	CloseHandle(hQuery);
 	
-    Format(sQuery, sizeof(sQuery),
-            "SELECT categoryid FROM categories WHERE categoryname='%s'",
-            category);
-    hQuery = SQL_Query(g_hDatabase, sQuery);
-    
-    SQL_FetchRow(hQuery);
-    iCategoryID = SQL_FetchInt(hQuery, 0);
-    
-    CloseHandle(hQuery);
-    
-    return iCategoryID;
+	Format(sQuery, sizeof(sQuery),
+			"SELECT categoryid FROM categories WHERE categoryname='%s'",
+			category);
+	hQuery = SQL_Query(g_hDatabase, sQuery);
+	
+	SQL_FetchRow(hQuery);
+	iCategoryID = SQL_FetchInt(hQuery, 0);
+	
+	CloseHandle(hQuery);
+	
+	return iCategoryID;
 }
 
 public Native_RegClientDownloadCategory(Handle:hPlugin, nParams) {
-    decl String:category[512], String:description[512];
-    
-    GetNativeString(1, category, sizeof(category));
-    GetNativeString(2, description, sizeof(description));
-    new bool:bDefault = GetNativeCell(3);
-    
-    return RegClientDownloadCategory(category, description, bDefault);
+	decl String:category[512], String:description[512];
+	
+	GetNativeString(1, category, sizeof(category));
+	GetNativeString(2, description, sizeof(description));
+	new bool:bDefault = GetNativeCell(3);
+	
+	return RegClientDownloadCategory(category, description, bDefault);
 }
 
 /**
  * Registers a file to a category.
  * 
- * @param categoryid        The ID of the category to register.
- * @param filepath          The full path of the file to download.
+ * @param categoryid		The ID of the category to register.
+ * @param filepath			The full path of the file to download.
  */
 RegClientDownloadFile(categoryid, const String:filepath[]) {
-    decl String:sQuery[1024];
-    Format(sQuery, sizeof(sQuery),
-            "INSERT OR REPLACE INTO files (categoryid, filepath) VALUES (%d, '%s')",
-            categoryid, filepath);
-    SQL_FastQuery(g_hDatabase, sQuery);
+	decl String:sQuery[1024];
+	Format(sQuery, sizeof(sQuery),
+			"INSERT OR REPLACE INTO files (categoryid, filepath) VALUES (%d, '%s')",
+			categoryid, filepath);
+	SQL_FastQuery(g_hDatabase, sQuery);
 }
 
 public Native_RegClientDownloadFile(Handle:hPlugin, nParams) {
-    new categoryid = GetNativeCell(1);
-    
-    decl String:filepath[512];
-    GetNativeString(2, filepath, sizeof(filepath));
-    
-    RegClientDownloadFile(categoryid, filepath);
+	new categoryid = GetNativeCell(1);
+	
+	decl String:filepath[512];
+	GetNativeString(2, filepath, sizeof(filepath));
+	
+	RegClientDownloadFile(categoryid, filepath);
 }
 
 /**
  * Stores the client's download preference.
  * 
- * @param client            The client to set preferences for.
- * @param categoryid        The category of files to set a download preference for.
- * @param download          Whether or not the client downloads this file.
+ * @param client			The client to set preferences for.
+ * @param categoryid		The category of files to set a download preference for.
+ * @param download			Whether or not the client downloads this file.
  */
 SetClientDownloadPreference(client, categoryid, bool:enabled) {
-    decl String:sQuery[1024];
+	decl String:sQuery[1024];
 
-    new sid3 = GetSteamAccountID(client);
-    
-    if (ClientHasDownloadPreference(client, categoryid)) {
-        // Update existing entry.
-        Format(sQuery, sizeof(sQuery),
-                "UPDATE downloadprefs SET enabled = %d WHERE sid3 = %d AND categoryid = %d",
-                _:enabled, sid3, categoryid);
-    } else {
-        // Create new entry.
-        Format(sQuery, sizeof(sQuery),
-                "INSERT INTO downloadprefs (sid3, categoryid, enabled) VALUES (%d, %d, %d)",
-                sid3, categoryid, _:enabled);
-    }
-    SQL_FastQuery(g_hDatabase, sQuery);
+	new sid3 = GetSteamAccountID(client);
+	
+	if (ClientHasDownloadPreference(client, categoryid)) {
+		// Update existing entry.
+		Format(sQuery, sizeof(sQuery),
+				"UPDATE downloadprefs SET enabled = %d WHERE sid3 = %d AND categoryid = %d",
+				_:enabled, sid3, categoryid);
+	} else {
+		// Create new entry.
+		Format(sQuery, sizeof(sQuery),
+				"INSERT INTO downloadprefs (sid3, categoryid, enabled) VALUES (%d, %d, %d)",
+				sid3, categoryid, _:enabled);
+	}
+	SQL_FastQuery(g_hDatabase, sQuery);
 }
 
 public Native_SetClientDownloadPreference(Handle:hPlugin, nParams) {
-    new client = GetNativeCell(1),
-        categoryid = GetNativeCell(2),
-        bool:enabled = GetNativeCell(3);
+	new client = GetNativeCell(1),
+		categoryid = GetNativeCell(2),
+		bool:enabled = GetNativeCell(3);
 
-    SetClientDownloadPreference(client, categoryid, enabled);
+	SetClientDownloadPreference(client, categoryid, enabled);
 }
 
 /**
  * Retrieves a client's download preference.  If non-existent, will return the default setting.
  * A client will keep their existing download preference until a map change or reconnect.
  * 
- * @param client            The client to get preferences for.
- * @param categoryid        The category of files to get a download preference for.
+ * @param client			The client to get preferences for.
+ * @param categoryid		The category of files to get a download preference for.
  * 
- * @return                  Boolean determining if a client allows downloads from this category,
- *                          or the default allow value if the client has not set their own.
+ * @return					Boolean determining if a client allows downloads from this category,
+ *							or the default allow value if the client has not set their own.
  */
 bool:GetClientDownloadPreference(client, categoryid) {
-    decl String:sQuery[1024];
-    new bool:bEnabled;
-    
-    if (!ClientHasDownloadPreference(client, categoryid, bEnabled)) {
-        Format(sQuery, sizeof(sQuery),
-                "SELECT enabled FROM categories WHERE categoryid=%d",
-                categoryid);
-        bEnabled = bool:SQL_QuerySingleRowInt(g_hDatabase, sQuery);
-    }
-    
-    return bEnabled;
+	decl String:sQuery[1024];
+	new bool:bEnabled;
+	
+	if (!ClientHasDownloadPreference(client, categoryid, bEnabled)) {
+		Format(sQuery, sizeof(sQuery),
+				"SELECT enabled FROM categories WHERE categoryid=%d",
+				categoryid);
+		bEnabled = bool:SQL_QuerySingleRowInt(g_hDatabase, sQuery);
+	}
+	
+	return bEnabled;
 }
 
 public Native_GetClientDownloadPreference(Handle:hPlugin, nParams) {
-    new client = GetNativeCell(1),
-        categoryid = GetNativeCell(2);
+	new client = GetNativeCell(1),
+		categoryid = GetNativeCell(2);
 
-    return GetClientDownloadPreference(client, categoryid);
+	return GetClientDownloadPreference(client, categoryid);
 }
 
 /**
  * Checks whether or not the client has their own download preference set.
  * 
- * @param client            The client to check preferences for.
- * @param categoryid        The category of files to check for download preferences.
- * @param value             A cell reference to store an existing preference value.
+ * @param client			The client to check preferences for.
+ * @param categoryid		The category of files to check for download preferences.
+ * @param value				A cell reference to store an existing preference value.
  * 
- * @return                  Boolean determining if a custom download preference is set.
- *                          (False if using the default preference set by the download category.)
+ * @return					Boolean determining if a custom download preference is set.
+ *							(False if using the default preference set by the download category.)
  */
 bool:ClientHasDownloadPreference(client, categoryid, &any:result = 0) {
-    new sid3 = GetSteamAccountID(client);
-    decl String:sQuery[1024];
-    new Handle:hQuery = INVALID_HANDLE;
-    new bool:bHasRows;
+	new sid3 = GetSteamAccountID(client);
+	decl String:sQuery[1024];
+	new Handle:hQuery = INVALID_HANDLE;
+	new bool:bHasRows;
 
-    Format(sQuery, sizeof(sQuery),
-            "SELECT enabled FROM downloadprefs WHERE sid3=%d AND categoryid=%d",
-            sid3, categoryid);
-    hQuery = SQL_Query(g_hDatabase, sQuery);
-    
-    bHasRows = (SQL_GetRowCount(hQuery) > 0);
-    
-    if (bHasRows) {
-        SQL_FetchRow(hQuery);
-        result = bool:SQL_FetchInt(hQuery, 0);
-    }
-    
-    CloseHandle(hQuery);
-    
-    return bHasRows;
+	Format(sQuery, sizeof(sQuery),
+			"SELECT enabled FROM downloadprefs WHERE sid3=%d AND categoryid=%d",
+			sid3, categoryid);
+	hQuery = SQL_Query(g_hDatabase, sQuery);
+	
+	bHasRows = (SQL_GetRowCount(hQuery) > 0);
+	
+	if (bHasRows) {
+		SQL_FetchRow(hQuery);
+		result = bool:SQL_FetchInt(hQuery, 0);
+	}
+	
+	CloseHandle(hQuery);
+	
+	return bHasRows;
 }
 
 public Native_ClientHasDownloadPreference(Handle:hPlugin, nParams) {
-    new client = GetNativeCell(1),
-        categoryid = GetNativeCell(2),
-        result = GetNativeCellRef(3);
+	new client = GetNativeCell(1),
+		categoryid = GetNativeCell(2),
+		result = GetNativeCellRef(3);
 
-    return ClientHasDownloadPreference(client, categoryid, result);
+	return ClientHasDownloadPreference(client, categoryid, result);
 }
 
 /**
  * Runs a query, returning the selected integer from the first row.
  */
 _:SQL_QuerySingleRowInt(Handle:database, const String:query[]) {
-    new result;
-    new Handle:hQuery = SQL_Query(database, query);
-    
-    result = SQL_FetchInt(hQuery, 0);
-    CloseHandle(hQuery);
-    
-    return result;
+	new result;
+	new Handle:hQuery = SQL_Query(database, query);
+	
+	result = SQL_FetchInt(hQuery, 0);
+	CloseHandle(hQuery);
+	
+	return result;
 }
 
 /**
  * Reads the database configuration.
  */
-Handle:GetDatabase() {  
-    new Handle:hDatabase = INVALID_HANDLE;
-    
-    if (SQL_CheckConfig(DATABASE_NAME)) {
-        decl String:sErrorBuffer[256];
-        if ( (hDatabase = SQL_Connect(DATABASE_NAME, true, sErrorBuffer, sizeof(sErrorBuffer))) == INVALID_HANDLE ) {
-            SetFailState("[downloadprefs] Could not connect to database: %s", sErrorBuffer);
-        } else {
-            return hDatabase;
-        }
-    } else {
-        SetFailState("[downloadprefs] Could not find configuration %s to load database.", DATABASE_NAME);
-    }
-    return INVALID_HANDLE;
+Handle:GetDatabase() {	
+	new Handle:hDatabase = INVALID_HANDLE;
+	
+	if (SQL_CheckConfig(DATABASE_NAME)) {
+		decl String:sErrorBuffer[256];
+		if ( (hDatabase = SQL_Connect(DATABASE_NAME, true, sErrorBuffer, sizeof(sErrorBuffer))) == INVALID_HANDLE ) {
+			SetFailState("[downloadprefs] Could not connect to database: %s", sErrorBuffer);
+		} else {
+			return hDatabase;
+		}
+	} else {
+		SetFailState("[downloadprefs] Could not find configuration %s to load database.", DATABASE_NAME);
+	}
+	return INVALID_HANDLE;
 }
 
 /**
@@ -307,9 +307,9 @@ Handle:GetDatabase() {
   * Flow to check if a download is allowed.
   * When a client is authorized: -> Send custom virtual fastdl directory data
   * When a client downloads a file: ->
-  *   - Get SteamID3 from query string
-  *   - Get 'categoryid' by 'filepath' in table files (filepath obtained in query string),
-  *   - Get 'enabled' by 'sid3' and 'category' in downloadprefs,
-  *   - (If not found, get 'enabled' by 'categoryid' in table categories),
-  *   - If enabled, allow the download, otherwise redirect / 404.
+  *	  - Get SteamID3 from query string
+  *	  - Get 'categoryid' by 'filepath' in table files (filepath obtained in query string),
+  *	  - Get 'enabled' by 'sid3' and 'category' in downloadprefs,
+  *	  - (If not found, get 'enabled' by 'categoryid' in table categories),
+  *	  - If enabled, allow the download, otherwise redirect / 404.
   */

--- a/scripting/downloadprefs.sp
+++ b/scripting/downloadprefs.sp
@@ -7,7 +7,6 @@
  */
 
 #pragma semicolon 1
-
 #include <sourcemod>
 
 #define PLUGIN_VERSION			"0.4.0"
@@ -21,7 +20,6 @@ public Plugin:myinfo = {
 }
 
 #define DATABASE_NAME			"downloadprefs" // Database name in config
-
 new Handle:g_hDatabase = INVALID_HANDLE;
 
 new Handle:g_hCDownloadURL = INVALID_HANDLE, // sv_downloadurl
@@ -29,6 +27,8 @@ new Handle:g_hCDownloadURL = INVALID_HANDLE, // sv_downloadurl
 
 public OnPluginStart() {
 	g_hCDownloadURL = FindConVar("sv_downloadurl");
+	
+	CreateConVar("sm_dprefs_version", PLUGIN_VERSION, _, FCVAR_PLUGIN | FCVAR_NOTIFY);
 
 	// Set redirect downloadurl.  If blank, the transmission of sv_downloadurl to the client is not changed.
 	g_hCDPrefURL = CreateConVar("sm_dprefs_downloadurl", "", "Download URL to send to the client.  See README for details.", FCVAR_PLUGIN | FCVAR_SPONLY);

--- a/www/downloadprefs_sqlite.example.conf.php
+++ b/www/downloadprefs_sqlite.example.conf.php
@@ -1,0 +1,19 @@
+<?php
+	// Custom configuration file for downloadprefs.
+	// The $DPREFS.php will search for a file named $DPREFS.conf.php, where $DPREFS is the redirection script.
+
+	// Path to database file.
+	$dbFile = dirname(__FILE__) . '/clientproxy.sq3';
+	
+	// Redirected download path, refered to when redirecting the client to an accepted file.
+	// By default it will use http://server.domain/tf
+	$downloadDir = "http://$_SERVER[HTTP_HOST]/tf";
+	
+	// Error pages.  If you want to redirect any failures to a page, add them here.
+	// Of course most clients will probably never see this.
+	$errorPages = [
+		"opt-in-required" => NULL,
+		"unspecified-steamid" => NULL,
+		"unspecified-file" => NULL,
+	];
+?>

--- a/www/downloadprefs_sqlite.php
+++ b/www/downloadprefs_sqlite.php
@@ -1,31 +1,41 @@
 <?php
-	// Example redirected call:
+	// Example rewritten call:
 	// http://example.com/downloadprefs_sqlite.php?file=sound/ui/gamestartup10.mp3&steamid=46714374
 
-	$file = html_entity_decode($_REQUEST['file']);
+	// Required parameters:
+	//   - file: Path to file to check for download preferences
+	//   - steamid: The player's SteamID
+	
+	// Default settings
+	$dbFile = dirname(__FILE__) . '/clientproxy.sq3';
+	$downloadDir = "http://$_SERVER[HTTP_HOST]/tf";
+	$errorPages = [ "opt-in-required" => NULL, "unspecified-steamid" => NULL, "unspecified-file" => NULL, ];
+	
+	// Any values that exist in downloadprefs_sqlite.conf.php will overwrite the preferences above.
+	$configFile = dirname(__FILE__) . '/' . basename(__FILE__, '.php') . '.conf.php';
+	if (file_exists($configFile)) {
+		include_once($configFile);
+	}
+?>
 
+<?php
+	$file = html_entity_decode($_REQUEST['file']);
+	
 	if (!empty($file)) {
-		// Client IP when using the fastdl should normally match the IP given to the game server.
-		$ip = $_SERVER['REMOTE_ADDR'];
-		
 		// Queries database for non-bzipped version; easier than adding a check to test to add nonexistent .bz2 extension.
 		$filenobzip = str_replace(".bz2", "", $file);
 		
-		$db = new SQLite3('./clientproxy.sq3');
+		$db = new SQLite3($dbFile);
 		
 		/**
-		 * $sid3 will not exist for an IP address that did not use the server -- deny download.
 		 * $category might not exist if the file is not registered -- allow download anyways.
 		 * $enabled may not exist if the client has no preference set -- default to category.
-		 * 
-		 * Priority test: $sid3 > $category > $enabled
 		 */
 		
 		if (isset($_REQUEST['steamid'])) {
 			$sid3 = filter_var($_REQUEST['steamid'], FILTER_VALIDATE_INT);
 			
 			$category = $db->querySingle('SELECT categoryid FROM files WHERE filepath="'.SQLite3::escapeString($filenobzip).'"');
-			// TODO allow download if is_null($category)
 			
 			$enabled = $db->querySingle('SELECT enabled FROM downloadprefs WHERE sid3="'.$sid3.'" AND categoryid='.SQLite3::escapeString($category).'');
 			if (is_null($enabled)) {
@@ -37,22 +47,36 @@
 			// If the file is not registered or client did not set a custom preference, then allow.
 			if (is_null($category) || is_null($enabled) || $enabled == 1) {
 				header("HTTP/1.1 307 Temporary Redirect");
-				header("Location: http://$_SERVER[HTTP_HOST]/tf/$file" );
+				header("Location: $downloadDir/$file" );
 				return;
 			} else {
-				header("HTTP/1.1 404 File Not Found");
+				// This file is opt-in.
+				header("HTTP/1.1 403 Forbidden");
+				
+				$errorPage = $errorPages['opt-in-required'];
+				if (!is_null($errorPage)) {
+					header("Location: $errorPage");
+				}
+				return;
 			}
 		} else {
-			// Client is not allowed to download.
-			header("HTTP/1.1 404 File Not Found");
+			// Client has not specified a SteamID and accessed PHP page directly -- block download.
+			header("HTTP/1.1 403 Forbidden");
+			
+			$errorPage = $errorPages['unspecified-steamid'];
+			if (!is_null($errorPage)) {
+				header("Location: $errorPage");
+			}
 			return;
 		}
 	} else {
-		// Client did not pass a query -- assume they found sv_downloadurl, redirect to some explanation file?
-		header("HTTP/1.1 307 Temporary Redirect");
-	
-		$file = "downloadprefs.html";
-		header("Location: http://$_SERVER[HTTP_HOST]/tf/$file" );
+		// Client did not pass a file.
+		header("HTTP/1.1 403 Forbidden");
+		
+		$errorPage = $errorPages['unspecified-file'];
+		if (!is_null($errorPage)) {
+			header("Location: $errorPage");
+		}
 		return;
 	}
 ?>

--- a/www/downloadprefs_sqlite.php
+++ b/www/downloadprefs_sqlite.php
@@ -1,8 +1,8 @@
 <?php
-	// Example call:
-	// http://example.com/downloadprefs_sqlite.php?f=sound/ui/gamestartup10.mp3
+	// Example redirected call:
+	// http://example.com/downloadprefs_sqlite.php?file=sound/ui/gamestartup10.mp3&steamid=46714374
 
-	$file = html_entity_decode($_GET['f']);
+	$file = html_entity_decode($_REQUEST['file']);
 
 	if (!empty($file)) {
 		// Client IP when using the fastdl should normally match the IP given to the game server.
@@ -21,28 +21,27 @@
 		 * Priority test: $sid3 > $category > $enabled
 		 */
 		
-		// If the Source Engine is updated to provide SteamID in the header, we can use that and bypass the client IP / SteamID table altogether.
-		$sid3 = $db->querySingle('SELECT sid3 FROM clients WHERE ipaddr="'.SQLite3::escapeString($ip).'"');
-		if (is_null($sid3)) {
-			header("HTTP/1.1 403 Forbidden");
-			return;
-		}
-		
-		$category = $db->querySingle('SELECT categoryid FROM files WHERE filepath="'.SQLite3::escapeString($filenobzip).'"');
-		// TODO allow download if is_null($category)
-		
-		$enabled = $db->querySingle('SELECT enabled FROM downloadprefs WHERE sid3="'.$sid3.'" AND categoryid='.SQLite3::escapeString($category).'');
-		if (is_null($enabled)) {
-			$enabled = $db->querySingle('SELECT enabled FROM categories WHERE categoryid='.$category);
-		}
-		
-		$db->close();
-		
-		// If the file is not registered or client did not set a custom preference, then allow.
-		if (is_null($category) || is_null($enabled) || $enabled == 1) {
-			header("HTTP/1.1 307 Temporary Redirect");
-			header("Location: http://$_SERVER[HTTP_HOST]/tf/$file" );
-			return;
+		if (isset($_REQUEST['steamid'])) {
+			$sid3 = filter_var($_REQUEST['steamid'], FILTER_VALIDATE_INT);
+			
+			$category = $db->querySingle('SELECT categoryid FROM files WHERE filepath="'.SQLite3::escapeString($filenobzip).'"');
+			// TODO allow download if is_null($category)
+			
+			$enabled = $db->querySingle('SELECT enabled FROM downloadprefs WHERE sid3="'.$sid3.'" AND categoryid='.SQLite3::escapeString($category).'');
+			if (is_null($enabled)) {
+				$enabled = $db->querySingle('SELECT enabled FROM categories WHERE categoryid='.$category);
+			}
+			
+			$db->close();
+			
+			// If the file is not registered or client did not set a custom preference, then allow.
+			if (is_null($category) || is_null($enabled) || $enabled == 1) {
+				header("HTTP/1.1 307 Temporary Redirect");
+				header("Location: http://$_SERVER[HTTP_HOST]/tf/$file" );
+				return;
+			} else {
+				header("HTTP/1.1 404 File Not Found");
+			}
 		} else {
 			// Client is not allowed to download.
 			header("HTTP/1.1 404 File Not Found");


### PR DESCRIPTION
These changes alter the functionality of the downloadprefs system.  Instead of supplying the same `sv_downloadurl` to all clients and having the server figure out which IP points to which SteamID, the SourceMod plugin sends a custom `sv_downloadurl` value to the client as it connects and requests files.  All the fastdownload server needs to do is check whether the SteamID specified is allowed to download the requested file.

This change requires a change in the rewrite rule (from supplying just a file path to also supplying a SteamID), but the other files should be drop-in replacements; no plugin modifications are necessary.

The `clients` table can also be dropped.
